### PR TITLE
Fix action cache problem

### DIFF
--- a/.github/workflows/daily_menu.yml
+++ b/.github/workflows/daily_menu.yml
@@ -25,8 +25,8 @@ jobs:
     - name: Cache Ruby gems
       uses: actions/cache@v3
       with:
-        path: ~/.bundle
-        key: ${{ runner.os }}-ruby-${{ hashFiles('**/Gemfile.lock') }}
+        path: vendor/bundle
+        key: ${{ runner.os }}-ruby-${{ hashFiles('Gemfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-ruby-
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'nokogiri'
+gem 'firebase'
+gem 'google-cloud-firestore'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,91 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    base64 (0.2.0)
+    bigdecimal (3.1.9)
+    concurrent-ruby (1.3.5)
+    faraday (2.8.1)
+      base64
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
+    faraday-retry (2.2.1)
+      faraday (~> 2.0)
+    firebase (0.2.8)
+      googleauth
+      httpclient (>= 2.5.3)
+      json
+    gapic-common (0.21.1)
+      faraday (>= 1.9, < 3.a)
+      faraday-retry (>= 1.0, < 3.a)
+      google-protobuf (~> 3.18)
+      googleapis-common-protos (>= 1.4.0, < 2.a)
+      googleapis-common-protos-types (>= 1.11.0, < 2.a)
+      googleauth (~> 1.9)
+      grpc (~> 1.59)
+    google-cloud-core (1.7.1)
+      google-cloud-env (>= 1.0, < 3.a)
+      google-cloud-errors (~> 1.0)
+    google-cloud-env (2.1.1)
+      faraday (>= 1.0, < 3.a)
+    google-cloud-errors (1.4.0)
+    google-cloud-firestore (2.16.0)
+      bigdecimal (~> 3.0)
+      concurrent-ruby (~> 1.0)
+      google-cloud-core (~> 1.5)
+      google-cloud-firestore-v1 (>= 0.10, < 2.a)
+      rbtree (~> 0.4.2)
+    google-cloud-firestore-v1 (1.1.1)
+      gapic-common (>= 0.21.1, < 2.a)
+      google-cloud-errors (~> 1.0)
+      google-cloud-location (>= 0.7, < 2.a)
+    google-cloud-location (0.8.1)
+      gapic-common (>= 0.21.1, < 2.a)
+      google-cloud-errors (~> 1.0)
+    google-protobuf (3.25.5-x86_64-linux)
+    googleapis-common-protos (1.6.0)
+      google-protobuf (>= 3.18, < 5.a)
+      googleapis-common-protos-types (~> 1.7)
+      grpc (~> 1.41)
+    googleapis-common-protos-types (1.18.0)
+      google-protobuf (>= 3.18, < 5.a)
+    googleauth (1.11.2)
+      faraday (>= 1.0, < 3.a)
+      google-cloud-env (~> 2.1)
+      jwt (>= 1.4, < 3.0)
+      multi_json (~> 1.11)
+      os (>= 0.9, < 2.0)
+      signet (>= 0.16, < 2.a)
+    grpc (1.65.2-x86_64-linux)
+      google-protobuf (>= 3.25, < 5.0)
+      googleapis-common-protos-types (~> 1.0)
+    httpclient (2.8.3)
+    json (2.9.1)
+    jwt (2.10.1)
+      base64
+    multi_json (1.15.0)
+    nokogiri (1.15.7-x86_64-linux)
+      racc (~> 1.4)
+    os (1.1.4)
+    public_suffix (5.1.1)
+    racc (1.8.1)
+    rbtree (0.4.6)
+    ruby2_keywords (0.0.5)
+    signet (0.19.0)
+      addressable (~> 2.8)
+      faraday (>= 0.17.5, < 3.a)
+      jwt (>= 1.5, < 3.0)
+      multi_json (~> 1.10)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  firebase
+  google-cloud-firestore
+  nokogiri
+
+BUNDLED WITH
+   2.3.26


### PR DESCRIPTION
Add `Gemfile.lock` and `Gemfile` to the repository to address the action cache problem.

* **Gemfile.lock**: Add the `Gemfile.lock` file with the necessary dependencies and versions.
* **Gemfile**: Add the `Gemfile` file with the required gems `nokogiri`, `firebase`, and `google-cloud-firestore`.

